### PR TITLE
Update contributing.md

### DIFF
--- a/contributing/umbraco-cms/contributing.md
+++ b/contributing/umbraco-cms/contributing.md
@@ -33,7 +33,7 @@ The following steps are a quick-start guide:
    Switch to the `contrib` branch
 4.  **Build**
 
-    Build your fork of Umbraco locally [as described in the build documentation](build.md), you can build with any IDE that supports dotnet or the command line.
+    Build your fork of Umbraco locally as shown in the video below. You can build with any IDE that supports dotnet or the command line.
 
 {% embed url="https://youtu.be/JFc8JDAWDtA" %}
 


### PR DESCRIPTION
Removing link to the out of date build instructions

## Description

I removed a link to out of date documentation, pointing readers to the accurate video instead

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
v15 contributing docs


## Deadline (if relevant)

_When should the content be published?_
